### PR TITLE
Fix `IndexError` when no strings found

### DIFF
--- a/layout/usr/lib/python3.7/site-packages/zxtouch/client.py
+++ b/layout/usr/lib/python3.7/site-packages/zxtouch/client.py
@@ -370,6 +370,8 @@ class zxtouch:
         string_info_list = []
         raw_info_list = result[1]
         for raw_info in raw_info_list:
+            if not raw_info:
+                continue
             single_string_info = raw_info.split(",,")
             temp_dict = {"text": single_string_info[0], "x": single_string_info[1], "y": single_string_info[2],
                          "width": single_string_info[3], "height": single_string_info[4]}


### PR DESCRIPTION
Currently, I'm experiencing problems when the OCR worked, but no strings are present.

This PR fixes this issue.